### PR TITLE
Correctly handle -l flag in ekam-client

### DIFF
--- a/src/ekam/ekam-client.cpp
+++ b/src/ekam/ekam-client.cpp
@@ -82,8 +82,13 @@ int main(int argc, char* argv[]) {
   int maxDisplayedLogLines = 30;
   
   for (int i = 1; i < argc; i++) {
-    if (strcmp(argv[i], "-l") == 0 && i + 1 < argc) {
-      maxDisplayedLogLines = strtoul(argv[i+1], nullptr, 0);
+    if (strcmp(argv[i], "-l") == 0) {
+      char* endptr;
+      if (i + 1 >= argc ||
+          (maxDisplayedLogLines = strtoul(argv[++i], &endptr, 0), *endptr != '\0')) {
+        fprintf(stderr, "Expected number after -l.\n");
+        return 1;
+      }
     } else if (strcmp(argv[i], "-h") == 0 || strcmp(argv[i], "--help") == 0) {
       printf(
           "usage: nc <host> <port> | %s [-l <count>]\n"


### PR DESCRIPTION
It was impossible to pass a log line limit because -l did not consume
its argument, leading to this:

    $ ekam-client -l 100
    Unknown option: 100

This fixes the behaviour, and additionally checks that the argument in
fact a number.