### PR TITLE
Detect nodejs modules built for newer versions of v8

### DIFF
--- a/src/ekam/rules/compile.ekam-rule
+++ b/src/ekam/rules/compile.ekam-rule
@@ -167,8 +167,20 @@ case $OUTPUT in
     fi
     ;;
   * )
+    # Node v0.10 exports a symbol like so:
+    # NODE_MODULE_EXPORT node::node_module_struct modname ## _module = ...
+    #
+    # The HandleScope constructor is v8::HandleScope::HandleScope().
     if egrep -q ' D [a-z0-9]+_module' $SYMFILE && \
        grep -q _ZN2v811HandleScopeC1Ev $DEPFILE; then
+            echo provide "$OUTPUT_DISK_PATH" nodejs:module
+    fi
+    # Node v4 exports a symbol like so:
+    # static node::node_module _module = ...
+    #
+    # The HandleScope constructor is v8::HandleScope::HandleScope(v8::Isolate*)
+    if grep -q ' d _Z7_module' $SYMFILE && \
+       grep -q _ZN2v811HandleScopeC1EPNS_7IsolateE $DEPFILE; then
             echo provide "$OUTPUT_DISK_PATH" nodejs:module
     fi
     ;;


### PR DESCRIPTION
Node changed their ABI for native addons between v0.10 and v4.  For ekam to support nodejs modules intended to be used with node v4, we need to also detect the new symbols.