### PR TITLE
 Support limited cross-compilation.

### DIFF
--- a/README.md
+++ b/README.md
@@ -204,6 +204,19 @@ To specify some additional compiler options that should apply within a particula
 
 `.ekam-flags` files are actually executed using `/bin/sh` just before invoking the compiler. When multiple flags files are in-scope, the flags file in the outermost directory runs first.
 
+### Cross-compiling
+
+Ekam currently supports cross-compiling to multiple target architectures at once, by listing additional (non-host) architectures in the `CROSS_TARGETS` environment variable:
+
+    CROSS_TARGETS="aarch64-linux-gnu" ekam
+
+Notes:
+* This is designed to work e.g. with the `crossbuild-essential-*` Debian packages.
+* Ekam always compiles for the host architecture in addition to these targets. This is to support building tools like the Cap'n Proto compiler and then immediately using them in the same build.
+* Ekam assumes the inter-object dependencies are the same on all targets. This tends to mean that it work well for targetting alternate CPU architectures, but not as well for targeting other operating systems.
+* You may specify target-specific CXXFLAS and LIBS like `CXXFLAGS_aarch64_linux_gnu` and `LIBS_aarch64_linux_gnu`. If present, these completely replace the default `CXXFLAGS` and `LIBS`.
+* If any unit tests are built, Ekam will try to use qemu to run them.
+
 ## Custom Rules
 
 You may teach Ekam how to handle a new type of file -- or introduce a one-off build rule not triggered by any file -- by creating a rule file. A rule file is any executable with the extension `.ekam-rule`. Often, they are shell scripts, but this is not a requirement. Rule files can themselves be the output of other rules, so you could compile a C++ program that acts as a rule.

--- a/src/base/Promise.h
+++ b/src/base/Promise.h
@@ -591,7 +591,7 @@ template <typename ReturnType>
 struct CallAndFulfillFunctor {
   template <typename Callback, typename Func2, typename... Params>
   void operator()(WeakLink* linkToFulfiller, Callback* callback,
-                  const Func2& func, Params&&... params) const {
+                  Func2& func, Params&&... params) const {
     try {
       auto result = func(std::forward<Params>(params)...);
       if (linkToFulfiller->isEntangled()) {
@@ -607,7 +607,7 @@ template <>
 struct CallAndFulfillFunctor<void> {
   template <typename Callback, typename Func2, typename... Params>
   void operator()(WeakLink* linkToFulfiller, Callback* callback,
-                  const Func2& func, Params&&... params) const {
+                  Func2& func, Params&&... params) const {
     try {
       func(std::forward<Params>(params)...);
       if (linkToFulfiller->isEntangled()) {
@@ -701,7 +701,7 @@ private:
   struct DoReadyFunctor {
     template <typename... Params>
     void operator()(WeakLink* linkToFulfiller, Callback* callback,
-                    const Func& func, Params&&... params) const {
+                    Func& func, Params&&... params) const {
       CallAndFulfillFunctor<decltype(func(unpack(std::forward<Params>(params))...))>()(
           linkToFulfiller, callback, func, unpack(std::forward<Params>(params))...);
     }

--- a/src/ekam/rules/compile.ekam-rule
+++ b/src/ekam/rules/compile.ekam-rule
@@ -135,7 +135,7 @@ for TARGET in ${CROSS_TARGETS:-}; do
   SUFFIX="$(echo "$TARGET" | tr - _)"
   case "$(basename "$CXX")" in
     *clang* )
-      compile "$CXX" ".$TARGET.o" "$SUFFIX" -target "$TARGET" "-I/usr/$TARGET/include"
+      compile "$CXX" ".$TARGET.o" "$SUFFIX" -target "$TARGET" "-isystem/usr/$TARGET/include"
       ;;
     * )
       compile "$TARGET-$CXX" ".$TARGET.o" "$SUFFIX"

--- a/src/ekam/rules/compile.ekam-rule
+++ b/src/ekam/rules/compile.ekam-rule
@@ -97,28 +97,57 @@ OUTPUT=${MODULE_NAME}.o
 echo newOutput "$OUTPUT"
 read OUTPUT_DISK_PATH
 
-# Remove -Wglobal-constructors in tests because the test framework depends on registering global
-# objects, and we only care about global constructors in runtime code anyway.
-case "$CXXFLAGS" in
-  *-Wglobal-constructors* )
-    case "$MODULE_NAME" in
-      *-test )
-        CXXFLAGS="$CXXFLAGS -Wno-global-constructors"
-        ;;
-    esac
-esac
+compile() {
+  local TARGET_CXX="$1"
+  local SUFFIX="$2"
+  local FLAGSVAR="CXXFLAGS_$3"
+  shift 3
 
-# Compile!  We LD_PRELOAD intercept.so to intercept open() and other filesystem calls and convert
-# them into Ekam requests.  intercept.so expects file descriptors 3 and 4 to be the Ekam request
-# and response streams, so we remap them to stdout and stdin, respectively.  We also remap stdout
-# itself to stderr just to make sure that if the compiler prints anything to stdout (which normally
-# it shouldn't), that does not get misinterpreted as an Ekam request.
-#
-# The DYLD_ vars are the Mac OSX equivalent of LD_PRELOAD.  We don't bother checking which OS we're
-# on since the other vars will just be ignored anyway.
-LD_PRELOAD=$INTERCEPTOR DYLD_FORCE_FLAT_NAMESPACE= DYLD_INSERT_LIBRARIES=$INTERCEPTOR \
-    $CXX -I/ekam-provider/c++header $CXXFLAGS -c "/ekam-provider/canonical/$INPUT" \
-    -o "${MODULE_NAME}.o" 3>&1 4<&0 >&2
+  local FLAGS="$(eval "echo \"\${$FLAGSVAR:-\$CXXFLAGS}\"")"
+
+  # Remove -Wglobal-constructors in tests because the test framework depends on registering global
+  # objects, and we only care about global constructors in runtime code anyway.
+  case "$FLAGS" in
+    *-Wglobal-constructors* )
+      case "$MODULE_NAME" in
+        *-test )
+          FLAGS="$FLAGS -Wno-global-constructors"
+          ;;
+      esac
+  esac
+
+  # Compile!  We LD_PRELOAD intercept.so to intercept open() and other filesystem calls and convert
+  # them into Ekam requests.  intercept.so expects file descriptors 3 and 4 to be the Ekam request
+  # and response streams, so we remap them to stdout and stdin, respectively.  We also remap stdout
+  # itself to stderr just to make sure that if the compiler prints anything to stdout (which
+  # normally it shouldn't), that does not get misinterpreted as an Ekam request.
+  #
+  # The DYLD_ vars are the Mac OSX equivalent of LD_PRELOAD.  We don't bother checking which OS
+  # we're on since the other vars will just be ignored anyway.
+  LD_PRELOAD=$INTERCEPTOR DYLD_FORCE_FLAT_NAMESPACE= DYLD_INSERT_LIBRARIES=$INTERCEPTOR \
+      $TARGET_CXX -I/ekam-provider/c++header $FLAGS "$@" -c "/ekam-provider/canonical/$INPUT" \
+      -o "${MODULE_NAME}${SUFFIX}" 3>&1 4<&0 >&2
+}
+
+compile "$CXX" .o host
+
+for TARGET in ${CROSS_TARGETS:-}; do
+  SUFFIX="$(echo "$TARGET" | tr - _)"
+  case "$(basename "$CXX")" in
+    *clang* )
+      compile "$CXX" ".$TARGET.o" "$SUFFIX" -target "$TARGET" "-I/usr/$TARGET/include"
+      ;;
+    * )
+      compile "$TARGET-$CXX" ".$TARGET.o" "$SUFFIX"
+      ;;
+  esac
+done
+
+# TODO(someday): Generate symbols and deps separately for each target? Currently this is aimed at
+#   architecture cross-compiling, not OS cross-compiling, so we expect the symbols are identical.
+#   If they are not, the linker rule needs to change to understand this, too. Of course, what we
+#   should really do is handle separate targets using separate build steps, but that seems to
+#   require deep changes to Ekam.
 
 # Ask Ekam where to put the symbol and deps lists.
 echo newOutput "${MODULE_NAME}.o.syms"

--- a/src/ekam/rules/intercept.ekam-rule
+++ b/src/ekam/rules/intercept.ekam-rule
@@ -24,14 +24,22 @@ INPUT=intercept.c
 echo findProvider file:intercept.c
 read INPUT_DISK_PATH
 
-OUTPUT="${INPUT%.c}.so"
-echo newOutput "$OUTPUT"
-read OUTPUT_DISK_PATH
+handle_target() {
+  OUTPUT="${INPUT%.c}$1.so"
+  echo newOutput "$OUTPUT"
+  read OUTPUT_DISK_PATH
 
-if test `uname` = Linux; then
-  gcc -g -shared -Wall -Wl,-no-undefined -fPIC -o "$OUTPUT_DISK_PATH" "$INPUT_DISK_PATH" -ldl
-else
-  gcc -g -shared -Wall -fPIC -o "$OUTPUT_DISK_PATH" "$INPUT_DISK_PATH"
-fi
+  if test `uname` = Linux; then
+    ${2}gcc -g -shared -Wall -Wl,-no-undefined -fPIC -o "$OUTPUT_DISK_PATH" "$INPUT_DISK_PATH" -ldl
+  else
+    ${2}gcc -g -shared -Wall -fPIC -o "$OUTPUT_DISK_PATH" "$INPUT_DISK_PATH"
+  fi
 
-echo provide $OUTPUT_DISK_PATH special:ekam-interceptor
+  echo provide $OUTPUT_DISK_PATH special:ekam-interceptor$3
+}
+
+handle_target "" "" ""
+
+for TARGET in ${CROSS_TARGETS:-}; do
+  handle_target .${TARGET} ${TARGET}- -${TARGET}
+done

--- a/src/ekam/rules/test.ekam-rule
+++ b/src/ekam/rules/test.ekam-rule
@@ -26,11 +26,20 @@ fi
 echo findInput "$1"
 read TEST_PROG
 
+INTERCEPTOR_TAG=special:ekam-interceptor
+
+for TARGET in ${CROSS_TARGETS:-}; do
+  if test "${1%.$TARGET}" != "$1"; then
+    INTERCEPTOR_TAG="special:ekam-interceptor-$TARGET"
+    export QEMU_LD_PREFIX=/usr/$TARGET
+  fi
+done
+
 if grep -q EKAM_TEST_DISABLE_INTERCEPTOR "$TEST_PROG"; then
   # Test requested no interceptor.
   INTERCEPTOR=
 else
-  echo findProvider special:ekam-interceptor
+  echo findProvider "$INTERCEPTOR_TAG"
   read INTERCEPTOR
 
   if test "$INTERCEPTOR" = ""; then

--- a/src/ekam/rules/test.ekam-rule
+++ b/src/ekam/rules/test.ekam-rule
@@ -27,11 +27,13 @@ echo findInput "$1"
 read TEST_PROG
 
 INTERCEPTOR_TAG=special:ekam-interceptor
+INTERPRETER=
 
 for TARGET in ${CROSS_TARGETS:-}; do
   if test "${1%.$TARGET}" != "$1"; then
     INTERCEPTOR_TAG="special:ekam-interceptor-$TARGET"
     export QEMU_LD_PREFIX=/usr/$TARGET
+    INTERPRETER="qemu-${TARGET%-linux-gnu}-static"
   fi
 done
 
@@ -54,7 +56,7 @@ echo newOutput "${1}.log"
 read TEST_LOG
 
 if LD_PRELOAD=$INTERCEPTOR DYLD_FORCE_FLAT_NAMESPACE= DYLD_INSERT_LIBRARIES=$INTERCEPTOR \
-   $TEST_PROG 3>&1 4<&0 2>"$TEST_LOG" >&2; then
+   $INTERPRETER $TEST_PROG 3>&1 4<&0 2>"$TEST_LOG" >&2; then
 	echo passed
 	exit 0
 else


### PR DESCRIPTION
As added to the readme:

> ### Cross-compiling
>
> Ekam currently supports cross-compiling to multiple target architectures at once, by listing additional (non-host) architectures in the `CROSS_TARGETS` environment variable:
>
>     CROSS_TARGETS="aarch64-linux-gnu" ekam
>
> Notes:
> * This is designed to work e.g. with the `crossbuild-essential-*` Debian packages.
> * Ekam always compiles for the host architecture in addition to these targets. This is to support building tools like the Cap'n Proto compiler and then immediately using them in the same build.
> * Ekam assumes the inter-object dependencies are the same on all targets. This tends to mean that it work well for targetting alternate CPU architectures, but not as well for targeting other operating systems.
> * You may specify target-specific CXXFLAS and LIBS like `CXXFLAGS_aarch64_linux_gnu` and `LIBS_aarch64_linux_gnu`. If present, these completely replace the default `CXXFLAGS` and `LIBS`.
> * If any unit tests are built, Ekam will try to use qemu to run them.